### PR TITLE
Reduce Watched Threshold from 95% to 90%

### DIFF
--- a/content.js
+++ b/content.js
@@ -152,7 +152,7 @@ function onWatchLaterUrl() {
         let totalItemsToRemove = 0;
         for (let el of list) {
             let pgBar = el.querySelectorAll("#content")[0].querySelector("#progress");
-            if (pgBar && pgBar.style.width.replace(/%/, "") >= "95") {
+            if (pgBar && pgBar.style.width.replace(/%/, "") >= "90") {
                 totalItemsToRemove++;
             }
         }
@@ -163,7 +163,7 @@ function onWatchLaterUrl() {
         let itemsProcessed = 0;
         for (let el of list) {
             let pgBar = el.querySelectorAll("#content")[0].querySelector("#progress");
-            if (pgBar && pgBar.style.width.replace(/%/, "") >= "95") {
+            if (pgBar && pgBar.style.width.replace(/%/, "") >= "90") {
                 el.querySelector("#menu").querySelector("#interaction").click();
                 await wait(500);
                 if (document.querySelector("ytd-popup-container tp-yt-iron-dropdown").style.display == '') {

--- a/content.js
+++ b/content.js
@@ -152,7 +152,7 @@ function onWatchLaterUrl() {
         let totalItemsToRemove = 0;
         for (let el of list) {
             let pgBar = el.querySelectorAll("#content")[0].querySelector("#progress");
-            if (pgBar && pgBar.style.width == "100%") {
+            if (pgBar && pgBar.style.width.replace(/%/, "") >= "95%") {
                 totalItemsToRemove++;
             }
         }
@@ -163,7 +163,7 @@ function onWatchLaterUrl() {
         let itemsProcessed = 0;
         for (let el of list) {
             let pgBar = el.querySelectorAll("#content")[0].querySelector("#progress");
-            if (pgBar && pgBar.style.width == "100%") {
+            if (pgBar && pgBar.style.width.replace(/%/, "") >= "95%") {
                 el.querySelector("#menu").querySelector("#interaction").click();
                 await wait(500);
                 if (document.querySelector("ytd-popup-container tp-yt-iron-dropdown").style.display == '') {

--- a/content.js
+++ b/content.js
@@ -152,7 +152,7 @@ function onWatchLaterUrl() {
         let totalItemsToRemove = 0;
         for (let el of list) {
             let pgBar = el.querySelectorAll("#content")[0].querySelector("#progress");
-            if (pgBar && pgBar.style.width.replace(/%/, "") >= "95%") {
+            if (pgBar && pgBar.style.width.replace(/%/, "") >= "95") {
                 totalItemsToRemove++;
             }
         }
@@ -163,7 +163,7 @@ function onWatchLaterUrl() {
         let itemsProcessed = 0;
         for (let el of list) {
             let pgBar = el.querySelectorAll("#content")[0].querySelector("#progress");
-            if (pgBar && pgBar.style.width.replace(/%/, "") >= "95%") {
+            if (pgBar && pgBar.style.width.replace(/%/, "") >= "95") {
                 el.querySelector("#menu").querySelector("#interaction").click();
                 await wait(500);
                 if (document.querySelector("ytd-popup-container tp-yt-iron-dropdown").style.display == '') {


### PR DESCRIPTION
This PR adjusts the required watched percentage to remove a video from 100% to 90-100%. I wanted this because videos often have outros that I skip, which means I don't watch 100% of the video. In practice, I think YouTube marks a video as 100% watched if the user's watch percentage exceeds 95%, so this is really a change from 95+ to 90+.

| Video Length | 90% Threshold | Remaining |
|:---: | :---: | :---: |
| 0:05:00 | 0:04:30 | 0:00:30 |
| 0:10:00 | 0:09:00 | 0:01:00 |
| 0:20:00 | 0:18:00 | 0:02:00 |
| 0:40:00 | 0:36:00 | 0:04:00 |
| 1:20:00 | 1:12:00 | 0:08:00 |

The PR shows some type conversions and changes in the comparison logic (string vs. integer) I needed before I will be able to try allowing users to define a percentage in some kind of settings menu. If you'd like, you can edit the commit (lines 155 and 166) to 100 instead, which will leave behavior unchanged but introduce compatibility with user-selectable thresholds down the road, if I or someone else completes that part.